### PR TITLE
I2C Transaction buffer and bugfix

### DIFF
--- a/sim/Unit_Wrapper/TB_I2C_Wrapper.vhd
+++ b/sim/Unit_Wrapper/TB_I2C_Wrapper.vhd
@@ -24,7 +24,8 @@ architecture TESTBENCH of TB_I2C_Wrapper is
       HOST_DATA_BITS : integer := 8;
       -- IN_FREQ_HZ has to be minimum 4*I2C_FREQ_HZ
       IN_FREQ_HZ : integer := 12000000;
-      I2C_FREQ_HZ : integer := 100000
+      I2C_FREQ_HZ : integer := 100000;
+      I2C_BUF_LEN : integer := 10
     );
     Port ( 
       clk, rst : in STD_LOGIC;
@@ -63,7 +64,7 @@ architecture TESTBENCH of TB_I2C_Wrapper is
 
 begin
 
-  COMP: I2C_Wrapper generic map(8, 10000000, 100000) port map(tb_clk, tb_rst, tb_write_en, tb_access_mode, tb_unit_data_in, tb_unit_data_out, tb_scheduler_wanted, tb_scheduler_done, tb_error_to_host, tb_error_from_host, tb_SCL_no_pullup, tb_SDA_no_pullup);
+  COMP: I2C_Wrapper generic map(8, 10000000, 100000, 1) port map(tb_clk, tb_rst, tb_write_en, tb_access_mode, tb_unit_data_in, tb_unit_data_out, tb_scheduler_wanted, tb_scheduler_done, tb_error_to_host, tb_error_from_host, tb_SCL_no_pullup, tb_SDA_no_pullup);
 
   tb_SDA <= tb_SDA_no_pullup when tb_SDA_no_pullup /= 'Z' else 'H';
   tb_SCL <= tb_SCL_no_pullup when tb_SCL_no_pullup /= 'Z' else 'H';
@@ -96,7 +97,8 @@ begin
 
   SCL_en <= '1', '0' after 1*tbase,
     '1' after 101*tbase, '0' after 1951*tbase,
-    '1' after 2601*tbase, '0' after 6351*tbase;
+    '1' after 2601*tbase, '0' after 6351*tbase,
+    '1' after 8101*tbase, '0' after 10851*tbase;
 
   tb_exp_SCL <= '0' when SCL_en = '1' and SCL_temp = '0' else 'H';
 
@@ -107,24 +109,32 @@ begin
     '1' after 20*tbase, '0' after 21*tbase,
     '1' after 2500*tbase, '0' after 2501*tbase,
     '1' after 2550*tbase, '0' after 2551*tbase,
-    '1' after 2600*tbase, '0' after 2601*tbase; -- skipped with error
+    '1' after 2600*tbase, '0' after 2601*tbase, -- skipped with error
+    '1' after 8000*tbase, '0' after 8001*tbase,
+    '1' after 9500*tbase, '0' after 9501*tbase;
 
   tb_access_mode <= "00",
     "01" after 10*tbase, "00" after 11*tbase, -- Set adr.
     "00" after 20*tbase, "00" after 21*tbase, -- Send data
     "00" after 2500*tbase, "00" after 2501*tbase, -- Send data
     "10" after 2550*tbase, "00" after 2551*tbase, -- Recv data
-    "00" after 2600*tbase, "00" after 2601*tbase; -- Send data
+    "00" after 2600*tbase, "00" after 2601*tbase, -- Send data
+    "10" after 8000*tbase, "00" after 8001*tbase, -- Recv data
+    "10" after 9500*tbase, "00" after 9501*tbase; -- Recv data
 
   tb_unit_data_in <= "00000000",
-     "11000001" after 10*tbase, "00000000" after 11*tbase, -- 0x41
+     "11000001" after 10*tbase, "00000000" after 11*tbase, -- 0x41 (ignores MSB)
      "00001111" after 20*tbase, "00000000" after 21*tbase, -- 0x0F
      "10000001" after 2500*tbase, "00000000" after 2501*tbase, -- 0x81
      "00000000" after 2550*tbase, "00000000" after 2551*tbase, -- 0x00 (ignored - recv mode)
-     "11110000" after 2600*tbase, "00000000" after 2601*tbase; -- 0xF0
+     "11110000" after 2600*tbase, "00000000" after 2601*tbase, -- 0xF0
+     "00000000" after 8000*tbase, "00000000" after 8001*tbase, -- 0x00 (ignored - recv mode)
+     "00000000" after 9500*tbase, "00000000" after 9501*tbase; -- 0x00 (ignored - recv mode)
 
   tb_scheduler_done <= '0',
-    '1' after 6200*tbase, '0' after 6201*tbase;
+    '1' after 6200*tbase, '0' after 6201*tbase,
+    '1' after 9800*tbase, '0' after 9801*tbase,
+    '1' after 10700*tbase, '0' after 10701*tbase;
 
   tb_SDA_no_pullup <= 'Z',
     '0' after 927*tbase, 'Z' after 1027*tbase, --Adr ACK
@@ -132,13 +142,20 @@ begin
     '0' after 3427*tbase, 'Z' after 3527*tbase, --Adr ACK
     '0' after 4327*tbase, 'Z' after 4427*tbase, --Data ACK
     '0' after 5327*tbase, 'Z' after 5427*tbase, --Adr ACK
-    '0' after 5427*tbase, '0' after 5527*tbase, 'Z' after 5627*tbase, 'Z' after 5727*tbase, '0' after 5827*tbase, '0' after 5927*tbase, '0' after 6027*tbase, 'Z' after 6127*tbase; -- DATA (0x31)
+    '0' after 5427*tbase, '0' after 5527*tbase, 'Z' after 5627*tbase, 'Z' after 5727*tbase, '0' after 5827*tbase, '0' after 5927*tbase, '0' after 6027*tbase, 'Z' after 6127*tbase, -- DATA (0x31)
+    '0' after 8927*tbase, 'Z' after 9027*tbase, --Adr ACK
+    '0' after 9027*tbase, '0' after 9127*tbase, '0' after 9227*tbase, '0' after 9327*tbase, '0' after 9427*tbase, '0' after 9527*tbase, '0' after 9627*tbase, 'Z' after 9727*tbase, -- DATA (0x01)
+    '0' after 9927*tbase, '0' after 10027*tbase, '0' after 10127*tbase, '0' after 10227*tbase, '0' after 10327*tbase, '0' after 10427*tbase, '0' after 10527*tbase, 'Z' after 10627*tbase; -- DATA (0x01)
 
   tb_exp_unit_data_out <= (others => 'U'), (others => '0') after 1*tbase,
-    "00000000ZZ000Z" after 6179*tbase, (others => '0') after 6200*tbase;
+    "00000000ZZ000Z" after 6179*tbase, (others => '0') after 6200*tbase,
+    "0000000000000Z" after 9779*tbase, (others => '0') after 9800*tbase,
+    "0000000000000Z" after 10679*tbase, (others => '0') after 10700*tbase;
 
   tb_exp_scheduler_wanted <= 'U', '0' after 1*tbase,
-    '1' after 6179*tbase, '0' after 6200*tbase;
+    '1' after 6179*tbase, '0' after 6200*tbase,
+    '1' after 9779*tbase, '0' after 9800*tbase,
+    '1' after 10679*tbase, '0' after 10700*tbase;
   
   tb_exp_error_to_host <= '0';
 
@@ -165,7 +182,17 @@ begin
     '0' after 5427*tbase, '0' after 5527*tbase, 'H' after 5627*tbase, 'H' after 5727*tbase, '0' after 5827*tbase, '0' after 5927*tbase, '0' after 6027*tbase, 'H' after 6127*tbase, -- DATA (0x31)
     'H' after 6227*tbase, --NACK (Recv end)
     '0' after 6327*tbase, --STOP_PREP
-    'H' after 6377*tbase; --STOP
+    'H' after 6377*tbase, --STOP
+    '0' after 8077*tbase, --START
+    'H' after 8127*tbase, '0' after 8227*tbase, '0' after 8327*tbase, '0' after 8427*tbase, '0' after 8527*tbase, '0' after 8627*tbase, 'H' after 8727*tbase, 'H' after 8827*tbase, -- ADR (0x83)
+    '0' after 8927*tbase, --ACK
+    '0' after 9027*tbase, '0' after 9127*tbase, '0' after 9227*tbase, '0' after 9327*tbase, '0' after 9427*tbase, '0' after 9527*tbase, '0' after 9627*tbase, 'H' after 9727*tbase, -- DATA (0x01)
+    '0' after 9827*tbase, --ACK
+    '0' after 9927*tbase, '0' after 10027*tbase, '0' after 10127*tbase, '0' after 10227*tbase, '0' after 10327*tbase, '0' after 10427*tbase, '0' after 10527*tbase, 'H' after 10627*tbase, -- DATA (0x01) 
+    'H' after 10727*tbase, -- NACK
+    '0' after 10827*tbase, -- STOP_PREP
+    'H' after 10877*tbase; --STOP
+
  
   tb_error <= '0' when 
     (tb_exp_unit_data_out = tb_unit_data_out)

--- a/sim/Units/I2C_Unit/TB_I2C_Communication.vhd
+++ b/sim/Units/I2C_Unit/TB_I2C_Communication.vhd
@@ -47,11 +47,12 @@ architecture TESTBENCH of TB_I2C_Communication is
   signal tb_error_unit, tb_exp_error_unit : std_logic;
   constant tbase : time := 100 ns;
   signal tb_SDA_no_pullup : std_logic := 'Z';
+  signal tb_SDA_ext_no_pullup : std_logic := 'Z';
 
 begin
   COMP: I2C_Communication port map(tb_clk, tb_rst, tb_clk_en_read, tb_clk_en_write, tb_SDA, tb_SDA_no_pullup, tb_write_en, tb_addr_data, tb_mode_recv, tb_send_data, tb_data_saved, tb_recv_data, tb_recv_data_valid, tb_is_idle, tb_error_unit);
 
-  tb_SDA <= '0' when tb_SDA_no_pullup = '0' else 'H';
+  tb_SDA <= '0' when tb_SDA_no_pullup = '0' or tb_SDA_ext_no_pullup = '0' else 'H';
 
   -- 10 MHz
   CLOCK: process
@@ -69,7 +70,9 @@ begin
 
   tb_rst <= '1', '0' after 2*tbase;
 
-  tb_SDA_no_pullup <= 'Z';
+  tb_SDA_ext_no_pullup <= 'Z',
+    '0' after 29*tbase, 'Z' after 31*tbase,
+    '0' after 47*tbase, 'Z' after 49*tbase;
 
   tb_write_en <= '0',
     '1' after 10*tbase, '0' after 11*tbase;
@@ -97,11 +100,9 @@ begin
 
   tb_exp_SDA <= 'H',
     '0' after 12*tbase, 'H' after 23*tbase,
-    '0' after 27*tbase, 'H' after 29*tbase,
-    '0' after 31*tbase, 'H' after 33*tbase,
+    '0' after 27*tbase, 'H' after 33*tbase,
     '0' after 37*tbase, 'H' after 41*tbase,
-    '0' after 45*tbase, 'H' after 47*tbase,
-    '0' after 49*tbase, 'H' after 50*tbase;
+    '0' after 45*tbase, 'H' after 50*tbase;
 
   tb_error <= '0' when 
     (tb_exp_data_saved = tb_data_saved)

--- a/sim/Units/I2C_Unit/TB_I2C_Unit.vhd
+++ b/sim/Units/I2C_Unit/TB_I2C_Unit.vhd
@@ -142,6 +142,7 @@ begin
     '0' after 824*tbase, 'Z' after 834*tbase,
     '0' after 924*tbase, 'Z' after 934*tbase,
     '1' after 936*tbase, '0' after 945*tbase, '1' after 955*tbase, '0' after 965*tbase, '1' after 975*tbase, '0' after 985*tbase, '1' after 995*tbase, '1' after 1005*tbase, 'Z' after 1010*tbase,
+    '0' after 1294*tbase, 'Z' after 1304*tbase, -- Addr. ACK
     '1' after 1384*tbase, 'Z' after 1394*tbase; -- NACK
 
   tb_exp_data_saved <= '0',
@@ -189,7 +190,7 @@ begin
     '0' after 985*tbase, '1' after 995*tbase, 'H' after 1010*tbase,
     '0' after 1024*tbase, 'H' after 1029*tbase,
     '0' after 1209*tbase, 'H' after 1274*tbase,
-    '0' after 1284*tbase, 'H' after 1294*tbase, '1' after 1384*tbase,
+    '0' after 1284*tbase, 'H' after 1304*tbase, '1' after 1384*tbase,
     '0' after 1394*tbase, 'H' after 1399*tbase;
 
     tb_error <= '0' when

--- a/sim/Units/UART_Unit/TB_UART_Module.vhd
+++ b/sim/Units/UART_Unit/TB_UART_Module.vhd
@@ -52,7 +52,7 @@ architecture TESTBENCH of TB_UART_Module is
   signal tb_error_TB_Deserializer : std_logic;
   signal tb_error_TB_Buffer_Register_Deserializer : std_logic;
 begin
-  UARTUnit: TB_UART_Unit port map(tb_error_TB_UART_Unit);
+  UART_Unit: TB_UART_Unit port map(tb_error_TB_UART_Unit);
   Prescaler: TB_Prescaler port map(tb_error_TB_Prescaler);
   Serializer: TB_Serializer port map(tb_error_TB_Serializer);
   Buffer_Register_Serializer: TB_Buffer_Register_Serializer port map(tb_error_TB_Buffer_Register_Serializer);

--- a/src/Main_Unit.vhd
+++ b/src/Main_Unit.vhd
@@ -102,7 +102,8 @@ architecture Behavioral of Main_Unit is
     Generic (
       HOST_DATA_BITS : integer := 8;
       IN_FREQ_HZ : integer := 12000000;
-      I2C_FREQ_HZ : integer := 100000
+      I2C_FREQ_HZ : integer := 100000;
+      I2C_BUF_LEN : integer := 10
     );
     Port ( 
       clk, rst : in STD_LOGIC;
@@ -315,7 +316,7 @@ begin
   --! Unit 6 - SPI_Unit implemented via SPI_Wrapper.
   U06_SPI: SPI_Wrapper generic map(HOST_DATA_BITS, FPGA_FREQ, 9600, 1, 0, 0, 8) port map(clk, rst_ext_pack, unit_en(6), decoded_access_mode, unit_data_received, unit_data_send(6), unit_scheduler_wanted(6), unit_scheduler_done(6), error_to_host(6), error_from_host(6), spi_sck, spi_cs, spi_mosi, spi_miso_sync);
   --! Unit 7 - I2C_Unit implemented via I2C_Wrapper.
-  U07_I2C: I2C_Wrapper generic map(HOST_DATA_BITS, FPGA_FREQ, 100000) port map(clk, rst_ext_pack, unit_en(7), decoded_access_mode, unit_data_received, unit_data_send(7), unit_scheduler_wanted(7), unit_scheduler_done(7), error_to_host(7), error_from_host(7), i2c_scl, i2c_sda);
+  U07_I2C: I2C_Wrapper generic map(HOST_DATA_BITS, FPGA_FREQ, 100000, 10) port map(clk, rst_ext_pack, unit_en(7), decoded_access_mode, unit_data_received, unit_data_send(7), unit_scheduler_wanted(7), unit_scheduler_done(7), error_to_host(7), error_from_host(7), i2c_scl, i2c_sda);
   --! Unit 8 - ISSI_IS61WV5128BLL_SRAM_Unit implemented via ISSI_IS61WV5128BLL_SRAM_Wrapper.
   U08_RAM: ISSI_IS61WV5128BLL_SRAM_Wrapper generic map(HOST_DATA_BITS, FPGA_FREQ, 8) port map(clk, rst_ext_pack, unit_en(8), decoded_access_mode, unit_data_received, unit_data_send(8), unit_scheduler_wanted(8), unit_scheduler_done(8), error_to_host(8), error_from_host(8), sram_adr, sram_data, sram_oen, sram_cen, sram_wen);
   -------------- UNITS END ----------------

--- a/src/Unit_Wrapper/I2C_Wrapper.vhd
+++ b/src/Unit_Wrapper/I2C_Wrapper.vhd
@@ -12,8 +12,9 @@ use IEEE.NUMERIC_STD.all;
 --! @brief Wraps an I2C_Unit to handle host commands and interface with the scheduler.
 --! @details I2C uses MSB.  
 --! It uses repeated start when sending packages directly following on each other to different slaves or to the same slave with another mode (send/receive).  
---! Packages to the same slave with the same mode (send/receive) following on each other are directly sent after the ACK.
---! The Unit supports slave clock stretching.  
+--! Packages to the same slave with the same mode (send/receive) following on each other are directly sent after the ACK.  
+--! The internal buffer helps to have longer transactions by storing data while waiting for the previous items in the transaction to be processed.  
+--! The Unit supports slave clock stretching of slaves.  
 --! @note 
 --! - The I2C Unit does not work with multiple masters. It has to be the only master on the bus.\n
 --! - This unit can not be synced as the pin is inout!
@@ -33,7 +34,8 @@ entity I2C_Wrapper is
   Generic (
     HOST_DATA_BITS : integer := 8; --! Width of the host UART data in bits.
     IN_FREQ_HZ : integer := 12000000; --! Input clock frequency in Hz (must be at least 4x I2C_FREQ_HZ).
-    I2C_FREQ_HZ : integer := 100000 --! I2C bus frequency in Hz.
+    I2C_FREQ_HZ : integer := 100000; --! I2C bus frequency in Hz.
+    I2C_BUF_LEN : integer := 10 --! I2C buffer length in data bytes.
   );
   Port (
     clk : in STD_LOGIC; --! Clock signal.
@@ -82,19 +84,33 @@ architecture Behavioral of I2C_Wrapper is
   --! Indicates that a receive transaction is active.
   signal scheduling_active : std_logic := '0';
 
-  --! Buffer for data to send, zero-extended to 14 bits.
-  signal unit_data_in_buffer : std_logic_vector(13 downto 0) := (others => '0');
   --! Buffer for received data, zero-extended to 14 bits.
   signal unit_data_out_buffer : std_logic_vector(13 downto 0) := (others => '0');
+  --! @brief Subdata type for I2C buffered payload data.
+  --! @details Array of std_logic_vector used to store the payload data for each buffered I2C transaction.
+  type i2c_buf_data_t is array (I2C_BUF_LEN-1 downto 0) of std_logic_vector(13 downto 0); 
+  --! Buffer for data to send, zero-extended to 14 bits.
+  signal i2c_buf_data : i2c_buf_data_t := (others => (others => '0'));
 
-  --! Strobe to start I2C_Unit transaction.
-  signal I2C_write_en : std_logic := '0';
+  --! @brief Subdata type for I2C partner addresses.
+  --! @details Array of 7-bit std_logic_vector to store the target addresses for each buffered I2C transaction.
+  type i2c_buf_addr_t is array (I2C_BUF_LEN-1 downto 0) of std_logic_vector(6 downto 0); 
+  --! Buffer for the address of the data to send in the data buffer.
+  signal i2c_buf_addr: i2c_buf_addr_t := (others => (others => '0'));
+
+  --! @brief Subdata type for I2C receive mode flags.
+  --! @details Array of single-bit flags, where '1' indicates the transaction is a receive operation and '0' indicates a send operation. One element per buffered transaction.
+  type i2c_buf_recv_mode_t is array (I2C_BUF_LEN-1 downto 0) of std_logic; 
+  --! Buffer of mode flags: '1' for receive, '0' for send.
+  signal i2c_buf_recv_mode: i2c_buf_recv_mode_t := (others => '0');
+
+  --! The amount of free slots in the buffer.
+  signal free_i2c_buf_slots : natural range 0 to I2C_BUF_LEN := I2C_BUF_LEN;
+
+  --! Flag to start I2C_Unit transaction. Is '1' if any valid data is in the buffer, '0' otherwise.
+  signal i2c_write_en : std_logic := '0';
   --! Current 7-bit partner address.
   signal current_partner_adr : std_logic_vector(6 downto 0) := (others => '0');
-  --! Indicates I2C_Unit is ready for a new transaction.
-  signal I2C_ready : std_logic;
-  --! Mode flag: '1' for receive, '0' for send.
-  signal I2C_mode_recv : std_logic;
 
   --! Previous I2C_data_saved for edge detection.
   signal last_I2C_data_saved : std_logic;
@@ -106,32 +122,43 @@ architecture Behavioral of I2C_Wrapper is
   --! I2C_Unit output: receive data valid indicator.
   signal recv_data_valid : std_logic;
 
-  --! Error: I2C transaction attempted while not ready.
-  signal error_I2C_not_ready : std_logic := '0';
+  --! Error: I2C transaction attempted while no free space in buffer.
+  signal error_I2C_buffer_full : std_logic := '0';
   --! Error: I2C partner did not acknowledge.
   signal error_I2C_NACK : std_logic := '0';
 
 begin
   --! The I2C Unit handling the I2C communication.
-  I2C: I2C_Unit generic map(IN_FREQ_HZ, I2C_FREQ_HZ) port map(clk, rst, I2C_write_en, current_partner_adr, I2C_mode_recv, unit_data_in_buffer(7 downto 0), I2C_data_saved, unit_data_out_buffer(7 downto 0), recv_data_valid, error_I2C_NACK, SCL, SDA);
+  I2C: I2C_Unit generic map(IN_FREQ_HZ, I2C_FREQ_HZ) port map(clk, rst, i2c_write_en, i2c_buf_addr(0), i2c_buf_recv_mode(0), i2c_buf_data(0)(7 downto 0), I2C_data_saved, unit_data_out_buffer(7 downto 0), recv_data_valid, error_I2C_NACK, SCL, SDA);
 
-  --! Handles host write_en edges, sets partner address, and starts I2C transactions if ready.
+  --! Handles host write_en edges, sets partner address, and starts I2C transactions if ready by using a buffer.
   I2C_COMM: process(clk)
   begin
     if rising_edge(clk) then
       if rst = '1' then
-        error_I2C_not_ready <= '0';
-        unit_data_in_buffer(HOST_DATA_BITS-1 downto 0) <= (others => '0');
-        I2C_write_en <= '0';
-        I2C_mode_recv <= '0';
-        I2C_ready <= '1';
+        error_I2C_buffer_full <= '0';
         current_partner_adr <= (others => '0');
-      else      
-        error_I2C_not_ready <= '0';
+        i2c_buf_addr <= (others => (others => '0'));
+        i2c_buf_recv_mode <= (others => '0');
+        i2c_buf_data <= (others => (others => '0'));
+        free_i2c_buf_slots <= I2C_BUF_LEN;
+        i2c_write_en <= '0';
+      else
+        error_I2C_buffer_full <= '0';
         if last_I2C_data_saved = '0' and I2C_data_saved = '1' then
-          -- Data was saved
-          I2C_write_en <= '0';
-          I2C_ready <= '1';
+          -- Shift the data in the buffer one idx to the front if valid data exists
+          free_i2c_buf_slots <= free_i2c_buf_slots + 1;
+          if free_i2c_buf_slots < I2C_BUF_LEN - 1 then
+            -- Buffer not empty after the processed item is poped.
+            for i in 0 to I2C_BUF_LEN-2 loop
+              i2c_buf_addr(i) <= i2c_buf_addr(i+1);
+              i2c_buf_recv_mode(i) <= i2c_buf_recv_mode(i+1);
+              i2c_buf_data(i) <= i2c_buf_data(i+1);
+            end loop;
+          else
+            -- No data in buffer remaining
+            i2c_write_en <= '0';
+          end if;
         end if;
         if last_write_enable = '0' and write_en = '1' then
           -- Rising edge of write_en detected.
@@ -139,20 +166,22 @@ begin
             -- Set current partner address (access mode bit0=1).
             current_partner_adr <= unit_data_in(6 downto 0);
           else
-            if I2C_ready = '1' then
-              unit_data_in_buffer(HOST_DATA_BITS-1 downto 0) <= unit_data_in;
-              I2C_write_en <= '1';
-              I2C_ready <= '0';
+            if free_i2c_buf_slots > 0 then
+              -- Free buffer slot --> Take this slot
+              free_i2c_buf_slots <= free_i2c_buf_slots - 1;
+              i2c_write_en <= '1';
+              i2c_buf_addr(I2C_BUF_LEN - free_i2c_buf_slots) <= current_partner_adr;
               if access_mode(1) = '1' then
                 -- Receive data (access mode bit1=1).
-                I2C_mode_recv <= '1';
+                i2c_buf_recv_mode(I2C_BUF_LEN - free_i2c_buf_slots) <= '1';
               else
                 -- Send data (access mode bit1=0).
-                I2C_mode_recv <= '0';
+                i2c_buf_recv_mode(I2C_BUF_LEN - free_i2c_buf_slots) <= '0';
               end if;
+              i2c_buf_data(I2C_BUF_LEN - free_i2c_buf_slots)(HOST_DATA_BITS-1 downto 0) <= unit_data_in;
             else
-              -- Error: I2C not ready.
-              error_I2C_not_ready <= '1';
+              -- Error: No free buffer slot.
+              error_I2C_buffer_full <= '1';
             end if;
           end if;
         end if;
@@ -197,7 +226,7 @@ begin
       if rst = '1' then
         error_from_host <= '0';
       else
-        error_from_host <= error_I2C_not_ready or error_I2C_NACK;
+        error_from_host <= error_I2C_buffer_full or error_I2C_NACK;
       end if;
     end if;
   end process;

--- a/src/Units/I2C_Unit/I2C_Communication.vhd
+++ b/src/Units/I2C_Unit/I2C_Communication.vhd
@@ -13,7 +13,7 @@ entity I2C_Communication is
     clk_en_write : in std_logic; --! Prescaled enable pulse for write/update.
     SDA_in : in std_logic; --! Serial data input sampled from SDA line.
     SDA_out : out std_logic; --! Serial data output to SDA line ('0' drive, '1' release/open).
-    write_en : in std_logic; --! Strobe to start/continue a transaction.
+    write_en : in std_logic; --! Flag to start/continue a transaction.
     addr_data : in std_logic_vector(6 downto 0); --! 7-bit partner address.
     mode_recv : in std_logic; --! Mode select: '0' = write, '1' = read.
     send_data : in std_logic_vector(7 downto 0); --! Data byte to send in write mode.
@@ -31,7 +31,7 @@ architecture Behavioral of I2C_Communication is
   --! @details S=Send, R=Receive, A=Address, B=Bit, ACK_Z=ACK_Z_state, ACK_R=ACK_Read 
   type communication_state_type is (IDLE, START, PREP_REP_START, REP_START,
                                     SA0, SA1, SA2, SA3, SA4, SA5, SA6, SRW, AACK_Z, AACK_R,
-                                    SB0, SB1, SB2, SB3, SB4, SB5, SB6, SB7, SACK,
+                                    SB0, SB1, SB2, SB3, SB4, SB5, SB6, SB7, SACK, SACK_DELAY,
                                     RB0, RB1, RB2, RB3, RB4, RB5, RB6, RB7, RACK_Z, RACK_R,
                                     STOP_PREP, STOP, ERR
                                     );
@@ -136,10 +136,7 @@ begin
           when AACK_R => 
             -- Read ACK
             if clk_en_read = '1' then
-              if SDA_in = '1' then
-                -- NACK
-                communication_state <= ERR;
-              else 
+              if SDA_in = '0' then
                 -- ACK
                 if ctrl_reg(0) = '0' then
                   -- Send
@@ -148,6 +145,9 @@ begin
                   -- Receive
                   communication_state <= RB0;
                 end if;
+              else 
+                -- NACK
+                communication_state <= ERR;
               end if;
             end if;
           when SB0 => 
@@ -200,10 +200,7 @@ begin
           when RACK_R => 
             -- Read ACK
             if clk_en_read = '1' then
-              if SDA_in = '1' then
-                -- NACK
-                communication_state <= ERR;
-              else 
+              if SDA_in = '0' then
                 -- ACK
                 if write_en = '1' then
                   -- Send/Recv next
@@ -224,6 +221,9 @@ begin
                   -- Stop 
                   communication_state <= STOP_PREP;
                 end if;
+              else
+                -- NACK
+                communication_state <= ERR;
               end if;
             end if;
           when RB0 => 
@@ -279,18 +279,24 @@ begin
                   -- Receive next
                   SDA_out <= '0'; -- ACK to continue reading
                   data_saved <= '1';
-                  communication_state <= RB0;
+                  communication_state <= SACK_DELAY;
                 else
                   -- Send next or new addr --> Repeated Start
                   ctrl_reg <= addr_data & mode_recv;
                   send_reg <= send_data;
                   data_saved <= '1';
-                  communication_state <= REP_START; -- NACK --> SDA is already high --> No PREP needed
+                  communication_state <= PREP_REP_START;
                 end if;
               else 
                 -- Stop 
                 communication_state <= STOP_PREP;
               end if;
+            end if;
+          when SACK_DELAY =>
+            -- wait for the ACK of the receivced byte to be sent before reading the next data
+            if clk_en_write = '1' then
+              SDA_out <= '1';
+              communication_state <= RB0;
             end if;
           when ERR => 
             error <= '1';

--- a/src/Units/I2C_Unit/I2C_Unit.vhd
+++ b/src/Units/I2C_Unit/I2C_Unit.vhd
@@ -20,7 +20,7 @@ entity I2C_Unit is
   port(
     clk : in std_logic; --! Clock signal.
     rst : in std_logic; --! Reset signal.
-    write_en : in std_logic; --! Strobe to start a transaction (read or write).
+    write_en : in std_logic; --! Flag to start a transaction (read or write).
     adr : in std_logic_vector(6 downto 0); --! 7-bit partner address.
     mode_recv : in std_logic; --! Mode: '0' = write, '1' = read.
     send_data : in std_logic_vector(7 downto 0); --! Byte to send on write.
@@ -72,7 +72,7 @@ architecture Behavioral of I2C_Unit is
   --! Prescaled enable for write phase timing.
   signal clk_en_write : std_logic;
   --! Indicates I2C bus idle; releases SCL when '1'.
-  signal SCL_en : std_logic;
+  signal not_SCL_en : std_logic;
   --! Internal SDA input/output (open-drain control).
   signal SDA_in, SDA_out : std_logic;
   --! Internal SCL input/output (open-drain control).
@@ -81,14 +81,14 @@ architecture Behavioral of I2C_Unit is
 begin
 
   --! Instantiate I2C communication core.
-  COMM: I2C_Communication port map(clk, rst, clk_en_read, clk_en_write, SDA_in, SDA_out, write_en, adr, mode_recv, send_data, data_saved, recv_data, recv_data_valid, SCL_en, error);
+  COMM: I2C_Communication port map(clk, rst, clk_en_read, clk_en_write, SDA_in, SDA_out, write_en, adr, mode_recv, send_data, data_saved, recv_data, recv_data_valid, not_SCL_en, error);
   --! Instantiate I2C prescaler.
   PRES: I2C_Prescaler generic map(IN_FREQ_HZ, I2C_FREQ_HZ) port map(clk, rst, clk_en_read, clk_en_write, SCL_in, SCL_out);
   
   SDA     <= '0' when SDA_out = '0' else 'Z';
-  SDA_in  <= SDA;
+  SDA_in  <= SDA; -- '0' or 'H'
 
-  SCL     <= '0' when ((SCL_out = '0') and (not (SCL_en = '1'))) else 'Z';
-  SCL_in  <= SCL;
+  SCL     <= '0' when ((SCL_out = '0') and (not (not_SCL_en = '1'))) else 'Z';
+  SCL_in  <= SCL; -- '0' or 'H'
 
 end Behavioral;


### PR DESCRIPTION
# Description
<!-- Provide a short summary about what you have implemented. -->
- Added transaction buffer to ensure easy transaction handling of the host.
- Fixed transaction handling when sending multiple receive commands (No ACK sent between two receive commands)

# Purpose
<!-- Describe the reason/purpose why this needed to be implemented. -->
- Transaction handling without buffer was very hard to time for the host.
- No transaction of multiple receive commands was possible.

# Implementation
<!-- Describe how the implementation works. -->
- The buffer is a shift register which is shifted when an item was processed and there is another valid one.
The data is written in the buffer on the next free slot.
If the buffer is full, an error is sent to the host.
- The ACK is sent by adding a state in the state machine to delay the read of the next bit until the ACK is sent.

# Additional notes
<!-- Optional: Describe everything else important to know p.ex. ToDos, Screenshots, technical limitations, etc. -->
-

# Checklist
- [x] I have tested my Code on the hardware
- [x] I edited relating test benches
- [x] I edited the documentation and reviewed it

# Related issues
<!-- Link issues related to the bug -->
